### PR TITLE
Fix UnicodeEncodeError in doctor command on Windows

### DIFF
--- a/src/applypilot/cli.py
+++ b/src/applypilot/cli.py
@@ -360,7 +360,7 @@ def doctor() -> None:
     if RESUME_PATH.exists():
         results.append(("resume.txt", ok_mark, str(RESUME_PATH)))
     elif RESUME_PDF_PATH.exists():
-        results.append(("resume.txt", warn_mark, "Only PDF found — plain-text needed for AI stages"))
+        results.append(("resume.txt", warn_mark, "Only PDF found - plain-text needed for AI stages"))
     else:
         results.append(("resume.txt", fail_mark, "Run 'applypilot init' to add your resume"))
 
@@ -368,7 +368,7 @@ def doctor() -> None:
     if SEARCH_CONFIG_PATH.exists():
         results.append(("searches.yaml", ok_mark, str(SEARCH_CONFIG_PATH)))
     else:
-        results.append(("searches.yaml", warn_mark, "Will use example config — run 'applypilot init'"))
+        results.append(("searches.yaml", warn_mark, "Will use example config - run 'applypilot init'"))
 
     # jobspy (discovery dep installed separately)
     try:
@@ -442,13 +442,13 @@ def doctor() -> None:
     # Tier summary
     from applypilot.config import get_tier, TIER_LABELS
     tier = get_tier()
-    console.print(f"[bold]Current tier: Tier {tier} — {TIER_LABELS[tier]}[/bold]")
+    console.print(f"[bold]Current tier: Tier {tier} - {TIER_LABELS[tier]}[/bold]")
 
     if tier == 1:
-        console.print("[dim]  → Tier 2 unlocks: scoring, tailoring, cover letters (needs LLM API key)[/dim]")
-        console.print("[dim]  → Tier 3 unlocks: auto-apply (needs Claude Code CLI + Chrome + Node.js)[/dim]")
+        console.print("[dim]  -> Tier 2 unlocks: scoring, tailoring, cover letters (needs LLM API key)[/dim]")
+        console.print("[dim]  -> Tier 3 unlocks: auto-apply (needs Claude Code CLI + Chrome + Node.js)[/dim]")
     elif tier == 2:
-        console.print("[dim]  → Tier 3 unlocks: auto-apply (needs Claude Code CLI + Chrome + Node.js)[/dim]")
+        console.print("[dim]  -> Tier 3 unlocks: auto-apply (needs Claude Code CLI + Chrome + Node.js)[/dim]")
 
     console.print()
 


### PR DESCRIPTION
## Summary

- Replace non-ASCII characters (`—` U+2014, `→` U+2192) with ASCII equivalents (`-`, `->`) in `console.print()` calls inside the `doctor` command
- On Windows with CP1252 console encoding, these characters cause a crash: `UnicodeEncodeError: 'charmap' codec can't encode character '\u2192'`
- The `applypilot doctor` command exits with a traceback instead of completing

## Affected lines

- `resume.txt` WARN note (em dash)
- `searches.yaml` WARN note (em dash)
- Tier summary header (em dash)
- Tier 2/3 unlock hint messages (right arrow x3)

## Test plan

- [ ] Run `applypilot doctor` on Windows — should complete without `UnicodeEncodeError`
- [ ] Run `applypilot doctor` on Linux/Mac — output unchanged, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)