### PR TITLE
fix: use max_completion_tokens for gpt-4.1+, gpt-5.x, and o-series models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to ApplyPilot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **OpenAI newer models (gpt-4.1+, gpt-5.x, o-series) rejected with HTTP 400** — these models
+  require `max_completion_tokens` instead of the legacy `max_tokens` parameter. `_chat_compat()`
+  now detects the model prefix and sends the correct parameter automatically.
+
 ## [0.2.0] - 2026-02-17
 
 ### Added

--- a/src/applypilot/llm.py
+++ b/src/applypilot/llm.py
@@ -157,11 +157,20 @@ class LLMClient:
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
 
+        # Newer OpenAI models (gpt-4.1+, gpt-5.x, o-series) require
+        # max_completion_tokens instead of the legacy max_tokens parameter.
+        # Sending max_tokens to these models returns HTTP 400.
+        _new_param_models = ("gpt-4.1", "gpt-5", "o1", "o3", "o4")
+        if any(self.model.startswith(p) for p in _new_param_models):
+            token_param: dict[str, int] = {"max_completion_tokens": max_tokens}
+        else:
+            token_param = {"max_tokens": max_tokens}
+
         payload = {
             "model": self.model,
             "messages": messages,
             "temperature": temperature,
-            "max_tokens": max_tokens,
+            **token_param,
         }
 
         resp = self._client.post(


### PR DESCRIPTION
## Problem

Newer OpenAI models — `gpt-4.1`, `gpt-5.x`, `o1`, `o3`, `o4` — reject the legacy `max_tokens` parameter with **HTTP 400** and require `max_completion_tokens` instead. This means any user who sets `LLM_MODEL=gpt-5.2` (or any other newer model) gets an immediate 400 error on every LLM call, breaking scoring, tailoring, and cover letter generation entirely.

Relevant code before this fix (`llm.py` `_chat_compat()`):

```python
payload = {
    "model": self.model,
    "messages": messages,
    "temperature": temperature,
    "max_tokens": max_tokens,   # ← rejected by gpt-4.1+, gpt-5.x, o-series
}
```

## Fix

Detect the model prefix at call time and send the correct parameter:

```python
_new_param_models = ("gpt-4.1", "gpt-5", "o1", "o3", "o4")
if any(self.model.startswith(p) for p in _new_param_models):
    token_param = {"max_completion_tokens": max_tokens}
else:
    token_param = {"max_tokens": max_tokens}
```

- All other providers (Gemini compat, Gemini native, local/Ollama) are **unaffected** — they continue using `max_tokens` as before.
- The native Gemini path already uses `maxOutputTokens` and is untouched.
- No behaviour change for existing `gpt-4o`, `gpt-4o-mini`, or local model users.

## Testing

Verified manually with `gpt-5.2` — the 400 error is resolved and completions return successfully after this change. No existing automated tests cover `_chat_compat()` directly.