### PR TITLE
Fix: commit score/tailor/cover-letter results incrementally instead of in one final batch

### DIFF
--- a/src/applypilot/scoring/cover_letter.py
+++ b/src/applypilot/scoring/cover_letter.py
@@ -231,6 +231,8 @@ def run_cover_letters(min_score: int = 7, limit: int = 20,
     results: list[dict] = []
     error_count = 0
 
+    saved = 0
+
     for job in jobs:
         completed += 1
         try:
@@ -262,6 +264,17 @@ def run_cover_letters(min_score: int = 7, limit: int = 20,
             }
             results.append(result)
 
+            # Commit immediately -- if the process crashes or is interrupted,
+            # already-generated cover letters are safely persisted.
+            now = datetime.now(timezone.utc).isoformat()
+            conn.execute(
+                "UPDATE jobs SET cover_letter_path=?, cover_letter_at=?, "
+                "cover_attempts=COALESCE(cover_attempts,0)+1 WHERE url=?",
+                (result["path"], now, result["url"]),
+            )
+            conn.commit()
+            saved += 1
+
             elapsed = time.time() - t0
             rate = completed / elapsed if elapsed > 0 else 0
             log.info(
@@ -275,25 +288,15 @@ def run_cover_letters(min_score: int = 7, limit: int = 20,
             }
             error_count += 1
             results.append(result)
-            log.error("%d/%d [ERROR] %s -- %s", completed, len(jobs), job["title"][:40], e)
 
-    # Persist to DB: increment attempt counter for ALL, save path only for successes
-    now = datetime.now(timezone.utc).isoformat()
-    saved = 0
-    for r in results:
-        if r.get("path"):
-            conn.execute(
-                "UPDATE jobs SET cover_letter_path=?, cover_letter_at=?, "
-                "cover_attempts=COALESCE(cover_attempts,0)+1 WHERE url=?",
-                (r["path"], now, r["url"]),
-            )
-            saved += 1
-        else:
+            now = datetime.now(timezone.utc).isoformat()
             conn.execute(
                 "UPDATE jobs SET cover_attempts=COALESCE(cover_attempts,0)+1 WHERE url=?",
-                (r["url"],),
+                (job["url"],),
             )
-    conn.commit()
+            conn.commit()
+
+            log.error("%d/%d [ERROR] %s -- %s", completed, len(jobs), job["title"][:40], e)
 
     elapsed = time.time() - t0
     log.info("Cover letters done in %.1fs: %d generated, %d errors", elapsed, saved, error_count)

--- a/src/applypilot/scoring/scorer.py
+++ b/src/applypilot/scoring/scorer.py
@@ -147,19 +147,19 @@ def run_scoring(limit: int = 0, rescore: bool = False) -> dict:
 
         results.append(result)
 
+        # Commit immediately -- if the process crashes or is interrupted,
+        # already-scored jobs are safely persisted and won't be re-scored.
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            "UPDATE jobs SET fit_score = ?, score_reasoning = ?, scored_at = ? WHERE url = ?",
+            (result["score"], f"{result['keywords']}\n{result['reasoning']}", now, result["url"]),
+        )
+        conn.commit()
+
         log.info(
             "[%d/%d] score=%d  %s",
             completed, len(jobs), result["score"], job.get("title", "?")[:60],
         )
-
-    # Write scores to DB
-    now = datetime.now(timezone.utc).isoformat()
-    for r in results:
-        conn.execute(
-            "UPDATE jobs SET fit_score = ?, score_reasoning = ?, scored_at = ? WHERE url = ?",
-            (r["score"], f"{r['keywords']}\n{r['reasoning']}", now, r["url"]),
-        )
-    conn.commit()
 
     elapsed = time.time() - t0
     log.info("Done: %d scored in %.1fs (%.1f jobs/sec)", len(results), elapsed, len(results) / elapsed if elapsed > 0 else 0)

--- a/src/applypilot/scoring/tailor.py
+++ b/src/applypilot/scoring/tailor.py
@@ -544,6 +544,23 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
         results.append(result)
         stats[result.get("status", "error")] = stats.get(result.get("status", "error"), 0) + 1
 
+        # Commit immediately -- if the process crashes or is interrupted,
+        # already-tailored jobs are safely persisted and won't be redone.
+        now = datetime.now(timezone.utc).isoformat()
+        _success_statuses = {"approved", "approved_with_judge_warning"}
+        if result["status"] in _success_statuses:
+            conn.execute(
+                "UPDATE jobs SET tailored_resume_path=?, tailored_at=?, "
+                "tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
+                (result["path"], now, result["url"]),
+            )
+        else:
+            conn.execute(
+                "UPDATE jobs SET tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
+                (result["url"],),
+            )
+        conn.commit()
+
         elapsed = time.time() - t0
         rate = completed / elapsed if elapsed > 0 else 0
         log.info(
@@ -554,23 +571,6 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
             rate * 60,
             result["title"][:40],
         )
-
-    # Persist to DB: increment attempt counter for ALL, save path only for approved
-    now = datetime.now(timezone.utc).isoformat()
-    _success_statuses = {"approved", "approved_with_judge_warning"}
-    for r in results:
-        if r["status"] in _success_statuses:
-            conn.execute(
-                "UPDATE jobs SET tailored_resume_path=?, tailored_at=?, "
-                "tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
-                (r["path"], now, r["url"]),
-            )
-        else:
-            conn.execute(
-                "UPDATE jobs SET tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
-                (r["url"],),
-            )
-    conn.commit()
 
     elapsed = time.time() - t0
     log.info(


### PR DESCRIPTION
## Summary

The `score`, `tailor`, and `cover` pipeline stages each accumulate all per-job results in memory and only write/commit to the database **once, after every job in the batch has finished** — not incrementally per job.

This causes two real problems on any run of meaningful size:

- **A crash, kill, or interruption partway through a stage loses all progress for that stage**, even though the expensive part (the LLM calls, and for tailor/cover the resume/cover-letter files already written to disk) already completed successfully. On a batch of a few hundred jobs at several seconds-to-a-minute per LLM call, that's hours of redone work after any interruption.
- **`applypilot status` is misleading while a stage is running.** Scored/tailored/cover-letter counts stay at zero for the *entire* duration of a stage, even while it's actively making progress, because nothing has been committed yet for `status` to read. It looks like the pipeline is stuck when it isn't.

## Fix

Each stage now commits immediately after processing each individual job, instead of accumulating and writing once at the end.

The "don't reprocess already-completed jobs" behavior needed no new logic — it already existed via the job-selection queries filtering on the relevant column being `NULL` (`fit_score`, `tailored_resume_path`, `cover_letter_path`). It just wasn't reachable in practice, since nothing was ever committed for those filters to see mid-run. Restarting after an interruption now naturally resumes from where it left off.

## Scope

Deliberately narrow — just the three `run_scoring` / `run_tailoring` / `run_cover_letters` functions in `scoring/scorer.py`, `scoring/tailor.py`, `scoring/cover_letter.py`. No behavior change on a clean, uninterrupted run, other than `status` reflecting real progress instead of zeros throughout.

## Test plan

- [x] Verified all three files parse (`ast.parse`)
- [x] Verified a job's fit_score commits and is correctly excluded from the next `pending_score` query (confirms resume-skip behavior works)
- [x] Ran `applypilot status` mid-run before and after the fix — before: stuck at 0 scored for the entire stage; after: count increments in real time as each job completes
- [ ] Would appreciate a maintainer sanity-check on `tailor`/`cover_letter`'s attempt-counter semantics, since those two also increment a retry counter for failed jobs (unchanged behavior, just moved inside the loop)

Per-row commits add negligible overhead relative to the LLM call each row already waits on (milliseconds vs. seconds-to-minutes).