### PR TITLE
Cap claude CLI usage and filter scraped API noise from discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,12 @@
 # Copy to ~/.applypilot/.env and fill in your values.
 
 # LLM Provider (pick one)
-GEMINI_API_KEY=           # Gemini 2.0 Flash (recommended, cheapest)
+# GEMINI_API_KEY=           # Gemini 2.0 Flash (recommended, cheapest)
 # OPENAI_API_KEY=         # OpenAI (GPT-4o-mini)
+ANTHROPIC_API_KEY=      # Anthropic Claude (Haiku 4.5)
+# USE_CLAUDE_CLI=true    # Claude via the `claude` CLI (uses your Claude
+                          # subscription instead of a metered API key;
+                          # requires `claude` on PATH and already logged in)
 # LLM_URL=http://127.0.0.1:8080/v1  # Local LLM (llama.cpp, Ollama)
 # LLM_MODEL=              # Override model name
 

--- a/src/applypilot/cli.py
+++ b/src/applypilot/cli.py
@@ -382,6 +382,8 @@ def doctor() -> None:
     import os
     has_gemini = bool(os.environ.get("GEMINI_API_KEY"))
     has_openai = bool(os.environ.get("OPENAI_API_KEY"))
+    has_claude_cli = bool(os.environ.get("USE_CLAUDE_CLI"))
+    has_anthropic = bool(os.environ.get("ANTHROPIC_API_KEY"))
     has_local = bool(os.environ.get("LLM_URL"))
     if has_gemini:
         model = os.environ.get("LLM_MODEL", "gemini-2.0-flash")
@@ -389,6 +391,12 @@ def doctor() -> None:
     elif has_openai:
         model = os.environ.get("LLM_MODEL", "gpt-4o-mini")
         results.append(("LLM API key", ok_mark, f"OpenAI ({model})"))
+    elif has_claude_cli:
+        model = os.environ.get("LLM_MODEL", "haiku")
+        results.append(("LLM API key", ok_mark, f"Claude CLI ({model})"))
+    elif has_anthropic:
+        model = os.environ.get("LLM_MODEL", "claude-haiku-4-5")
+        results.append(("LLM API key", ok_mark, f"Anthropic ({model})"))
     elif has_local:
         results.append(("LLM API key", ok_mark, f"Local: {os.environ.get('LLM_URL')}"))
     else:

--- a/src/applypilot/config.py
+++ b/src/applypilot/config.py
@@ -206,7 +206,10 @@ def get_tier() -> int:
     """
     load_env()
 
-    has_llm = any(os.environ.get(k) for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "LLM_URL"))
+    has_llm = any(
+        os.environ.get(k)
+        for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "USE_CLAUDE_CLI", "LLM_URL")
+    )
     if not has_llm:
         return 1
 
@@ -238,7 +241,10 @@ def check_tier(required: int, feature: str) -> None:
     _console = Console(stderr=True)
 
     missing: list[str] = []
-    if required >= 2 and not any(os.environ.get(k) for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "LLM_URL")):
+    if required >= 2 and not any(
+        os.environ.get(k)
+        for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "USE_CLAUDE_CLI", "LLM_URL")
+    ):
         missing.append("LLM API key — run [bold]applypilot init[/bold] or set GEMINI_API_KEY")
     if required >= 3:
         if not shutil.which("claude"):

--- a/src/applypilot/discovery/smartextract.py
+++ b/src/applypilot/discovery/smartextract.py
@@ -31,9 +31,28 @@ from playwright.sync_api import sync_playwright
 from applypilot import config
 from applypilot.config import CONFIG_DIR
 from applypilot.database import get_connection, init_db, store_jobs, get_stats
-from applypilot.llm import get_client
+from applypilot.llm import ClaudeUsageLimitError, get_client
 
 log = logging.getLogger(__name__)
+
+# Non-job noise that job-board frontends fire on every page load -- these
+# match the broad "/api/" response-capture heuristic below but are never
+# job data, so they're rejected before ever reaching the LLM judge.
+_NOISE_URL_PATTERNS = (
+    "/api/auth/",
+    "/api/telemetry/",
+    "/api/analytics/",
+    "get-session",
+    "web-vitals",
+    "geolocation",
+    "onetrust.com",
+    "cookieconsent",
+)
+
+
+def _is_noise_url(url: str) -> bool:
+    lowered = url.lower()
+    return any(p in lowered for p in _NOISE_URL_PATTERNS)
 
 # Fix Windows encoding -- prevents charmap errors on emoji/unicode in job titles
 if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
@@ -103,6 +122,9 @@ def _store_jobs_filtered(
         url = job.get("url")
         if not url:
             continue
+        if _is_noise_url(url):
+            filtered += 1
+            continue
         if not _location_ok(job.get("location"), accept_locs, reject_locs):
             filtered += 1
             continue
@@ -144,6 +166,8 @@ def collect_page_intelligence(url: str, headless: bool = True) -> dict:
         ct = response.headers.get("content-type", "")
         rurl = response.url
         if any(ext in rurl for ext in [".js", ".css", ".png", ".jpg", ".svg", ".woff", ".ico", ".gif", ".webp"]):
+            return
+        if _is_noise_url(rurl):
             return
         if "json" in ct or "/api/" in rurl or "algolia" in rurl or "graphql" in rurl:
             try:
@@ -401,9 +425,11 @@ def judge_api_responses(api_responses: list[dict]) -> list[dict]:
                      "KEEP" if is_relevant else "DROP", reason)
             if is_relevant:
                 relevant.append(resp)
+        except ClaudeUsageLimitError as e:
+            log.error("Judge stopped -- usage limit hit: %s", e)
+            break
         except Exception as e:
-            log.warning("Judge ERROR for %s: %s -- keeping", resp.get("url", "?")[:80], e)
-            relevant.append(resp)
+            log.warning("Judge ERROR for %s: %s -- dropping", resp.get("url", "?")[:80], e)
 
     return relevant
 

--- a/src/applypilot/llm.py
+++ b/src/applypilot/llm.py
@@ -4,13 +4,18 @@ Unified LLM client for ApplyPilot.
 Auto-detects provider from environment:
   GEMINI_API_KEY  -> Google Gemini (default: gemini-2.0-flash)
   OPENAI_API_KEY  -> OpenAI (default: gpt-4o-mini)
+  ANTHROPIC_API_KEY -> Anthropic Claude (default: claude-haiku-4-5)
+  USE_CLAUDE_CLI  -> Claude via the `claude` CLI (your Claude subscription,
+                     not a metered API key). Requires `claude` on PATH.
   LLM_URL         -> Local llama.cpp / Ollama compatible endpoint
 
 LLM_MODEL env var overrides the model name for any provider.
 """
 
+import json
 import logging
 import os
+import subprocess
 import time
 
 import httpx
@@ -29,6 +34,8 @@ def _detect_provider() -> tuple[str, str, str]:
     """
     gemini_key = os.environ.get("GEMINI_API_KEY", "")
     openai_key = os.environ.get("OPENAI_API_KEY", "")
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    use_claude_cli = os.environ.get("USE_CLAUDE_CLI", "")
     local_url = os.environ.get("LLM_URL", "")
     model_override = os.environ.get("LLM_MODEL", "")
 
@@ -46,6 +53,20 @@ def _detect_provider() -> tuple[str, str, str]:
             openai_key,
         )
 
+    if use_claude_cli and not local_url:
+        return (
+            _CLAUDE_CLI_MARKER,
+            model_override or "haiku",
+            "",
+        )
+
+    if anthropic_key and not local_url:
+        return (
+            _ANTHROPIC_BASE,
+            model_override or "claude-haiku-4-5",
+            anthropic_key,
+        )
+
     if local_url:
         return (
             local_url.rstrip("/"),
@@ -55,7 +76,7 @@ def _detect_provider() -> tuple[str, str, str]:
 
     raise RuntimeError(
         "No LLM provider configured. "
-        "Set GEMINI_API_KEY, OPENAI_API_KEY, or LLM_URL in your environment."
+        "Set GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, or LLM_URL in your environment."
     )
 
 
@@ -73,6 +94,9 @@ _RATE_LIMIT_BASE_WAIT = 10
 
 _GEMINI_COMPAT_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"
 _GEMINI_NATIVE_BASE = "https://generativelanguage.googleapis.com/v1beta"
+_ANTHROPIC_BASE = "https://api.anthropic.com/v1"
+_CLAUDE_CLI_MARKER = "claude-cli"  # not a real URL — signals the subprocess path
+_CLAUDE_CLI_TIMEOUT = 120  # seconds
 
 
 class LLMClient:
@@ -92,6 +116,8 @@ class LLMClient:
         # True once we've confirmed the native Gemini API works for this model
         self._use_native_gemini: bool = False
         self._is_gemini: bool = base_url.startswith(_GEMINI_COMPAT_BASE)
+        self._is_anthropic: bool = base_url == _ANTHROPIC_BASE
+        self._is_claude_cli: bool = base_url == _CLAUDE_CLI_MARKER
 
     # -- Native Gemini API --------------------------------------------------
 
@@ -143,6 +169,88 @@ class LLMClient:
         resp.raise_for_status()
         data = resp.json()
         return data["candidates"][0]["content"]["parts"][0]["text"]
+
+    # -- Anthropic Messages API ----------------------------------------------
+
+    def _chat_anthropic(
+        self,
+        messages: list[dict],
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        """Call the Anthropic Messages API.
+
+        Anthropic takes `system` as a top-level field rather than a message
+        role, so split it out of the OpenAI-style messages list.
+        """
+        system_text = "\n".join(msg.get("content", "") for msg in messages if msg["role"] == "system")
+        turns = [msg for msg in messages if msg["role"] != "system"]
+
+        payload: dict = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": turns,
+        }
+        if system_text:
+            payload["system"] = system_text
+
+        resp = self._client.post(
+            f"{self.base_url}/messages",
+            json=payload,
+            headers={
+                "Content-Type": "application/json",
+                "x-api-key": self.api_key,
+                "anthropic-version": "2023-06-01",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data["content"][0]["text"]
+
+    # -- Claude CLI (subscription, not a metered API key) --------------------
+
+    def _chat_claude_cli(
+        self,
+        messages: list[dict],
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        """Call the `claude` CLI in print mode.
+
+        Uses whatever the `claude` CLI is already logged into (a Claude
+        subscription), instead of a separate metered ANTHROPIC_API_KEY.
+        `claude -p` takes a single prompt string, not a chat history, so
+        multi-turn messages are flattened (this app's LLM calls are all
+        single-turn). `--disallowedTools *` keeps this a pure text
+        completion — no file/bash access.
+        """
+        system_text = "\n".join(msg.get("content", "") for msg in messages if msg["role"] == "system")
+        turns = [msg for msg in messages if msg["role"] != "system"]
+        prompt = (
+            turns[-1]["content"]
+            if len(turns) == 1
+            else "\n\n".join(f"{msg['role']}: {msg['content']}" for msg in turns)
+        )
+
+        cmd = ["claude", "-p", "--model", self.model, "--output-format", "json", "--disallowedTools", "*"]
+        if system_text:
+            cmd += ["--system-prompt", system_text]
+        cmd.append(prompt)
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_CLAUDE_CLI_TIMEOUT,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"claude CLI exited {result.returncode}: {result.stderr[:300]}")
+        data = json.loads(result.stdout)
+        if data.get("is_error"):
+            raise RuntimeError(f"claude CLI error: {data.get('result', 'unknown')}")
+        return data["result"]
 
     # -- OpenAI-compat API --------------------------------------------------
 
@@ -205,6 +313,12 @@ class LLMClient:
                 if self._use_native_gemini:
                     return self._chat_native_gemini(messages, temperature, max_tokens)
 
+                if self._is_anthropic:
+                    return self._chat_anthropic(messages, temperature, max_tokens)
+
+                if self._is_claude_cli:
+                    return self._chat_claude_cli(messages, temperature, max_tokens)
+
                 return self._chat_compat(messages, temperature, max_tokens)
 
             except _GeminiCompatForbidden as exc:
@@ -228,7 +342,7 @@ class LLMClient:
 
             except httpx.HTTPStatusError as exc:
                 resp = exc.response
-                if resp.status_code in (429, 503) and attempt < _MAX_RETRIES - 1:
+                if resp.status_code in (429, 503, 529) and attempt < _MAX_RETRIES - 1:
                     # Respect Retry-After header if provided (Gemini sends this).
                     retry_after = (
                         resp.headers.get("Retry-After")

--- a/src/applypilot/llm.py
+++ b/src/applypilot/llm.py
@@ -22,6 +22,34 @@ import httpx
 
 log = logging.getLogger(__name__)
 
+
+class ClaudeUsageLimitError(RuntimeError):
+    """Raised when the `claude` CLI reports a usage/rate limit, not a transient failure.
+
+    Distinguished from other CLI failures (bad prompt, malformed output, timeout)
+    so callers can stop a batch run immediately instead of burning retries into
+    a wall that won't clear until the limit window resets.
+    """
+
+
+# Substrings the `claude` CLI itself checks for when classifying provider
+# errors (see its own "Anthropic API:" error list) — matched case-insensitively
+# against stderr/result text to tell a real limit from any other failure.
+_USAGE_LIMIT_INDICATORS = (
+    "usage limit reached",
+    "rate limited",
+    "rate limit",
+    "credit balance too low",
+    "overloaded",
+    "429",
+    "529",
+)
+
+
+def _is_usage_limit_message(text: str) -> bool:
+    lowered = text.lower()
+    return any(indicator in lowered for indicator in _USAGE_LIMIT_INDICATORS)
+
 # ---------------------------------------------------------------------------
 # Provider detection
 # ---------------------------------------------------------------------------
@@ -87,6 +115,14 @@ def _detect_provider() -> tuple[str, str, str]:
 _MAX_RETRIES = 5
 _TIMEOUT = 120  # seconds
 
+# Hard cap on `claude` CLI calls for a single `applypilot run` process,
+# shared across every stage (score/judge/tailor/cover all route through the
+# same LLMClient singleton). Once hit, the next call raises instead of
+# spawning a subprocess, so a bad batch (e.g. junk scraped "jobs") can't
+# burn through the whole 5-hour subscription window unattended. There's no
+# real usage/quota API to read, so this is a local proxy, not a true count.
+_CLAUDE_CLI_CALL_BUDGET = int(os.environ.get("CLAUDE_CLI_CALL_BUDGET", "40"))
+
 # Base wait on first 429/503 (doubles each retry, caps at 60s).
 # Gemini free tier is 15 RPM = 4s minimum between requests; 10s gives headroom.
 _RATE_LIMIT_BASE_WAIT = 10
@@ -96,7 +132,7 @@ _GEMINI_COMPAT_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"
 _GEMINI_NATIVE_BASE = "https://generativelanguage.googleapis.com/v1beta"
 _ANTHROPIC_BASE = "https://api.anthropic.com/v1"
 _CLAUDE_CLI_MARKER = "claude-cli"  # not a real URL — signals the subprocess path
-_CLAUDE_CLI_TIMEOUT = 120  # seconds
+_CLAUDE_CLI_TIMEOUT = 240  # seconds
 
 
 class LLMClient:
@@ -118,6 +154,8 @@ class LLMClient:
         self._is_gemini: bool = base_url.startswith(_GEMINI_COMPAT_BASE)
         self._is_anthropic: bool = base_url == _ANTHROPIC_BASE
         self._is_claude_cli: bool = base_url == _CLAUDE_CLI_MARKER
+        self.claude_cli_call_count = 0
+        self.claude_cli_call_budget = _CLAUDE_CLI_CALL_BUDGET
 
     # -- Native Gemini API --------------------------------------------------
 
@@ -225,6 +263,13 @@ class LLMClient:
         single-turn). `--disallowedTools *` keeps this a pure text
         completion — no file/bash access.
         """
+        if self.claude_cli_call_count >= self.claude_cli_call_budget:
+            raise ClaudeUsageLimitError(
+                f"Local call budget exhausted ({self.claude_cli_call_count}/{self.claude_cli_call_budget} "
+                "calls this run) -- stopping before another CLI call to protect the 5-hour usage window. "
+                "Set CLAUDE_CLI_CALL_BUDGET to raise it."
+            )
+
         system_text = "\n".join(msg.get("content", "") for msg in messages if msg["role"] == "system")
         turns = [msg for msg in messages if msg["role"] != "system"]
         prompt = (
@@ -233,23 +278,40 @@ class LLMClient:
             else "\n\n".join(f"{msg['role']}: {msg['content']}" for msg in turns)
         )
 
+        # --disallowedTools takes a variadic list ("<tools...>") and swallows
+        # every bare argument after it, including a trailing prompt — so the
+        # prompt is sent via stdin instead of as a positional arg.
         cmd = ["claude", "-p", "--model", self.model, "--output-format", "json", "--disallowedTools", "*"]
         if system_text:
             cmd += ["--system-prompt", system_text]
-        cmd.append(prompt)
+
+        # ANTHROPIC_API_KEY in the subprocess env makes the CLI prefer that
+        # (metered) auth source over the claude.ai subscription login this
+        # path is meant to use, which it then refuses to do — unset it here.
+        cli_env = os.environ.copy()
+        cli_env.pop("ANTHROPIC_API_KEY", None)
 
         result = subprocess.run(
             cmd,
+            input=prompt,
             capture_output=True,
             text=True,
             timeout=_CLAUDE_CLI_TIMEOUT,
             check=False,
+            env=cli_env,
         )
         if result.returncode != 0:
-            raise RuntimeError(f"claude CLI exited {result.returncode}: {result.stderr[:300]}")
+            msg = f"claude CLI exited {result.returncode}: {result.stderr[:300]}"
+            if _is_usage_limit_message(result.stderr):
+                raise ClaudeUsageLimitError(msg)
+            raise RuntimeError(msg)
         data = json.loads(result.stdout)
         if data.get("is_error"):
-            raise RuntimeError(f"claude CLI error: {data.get('result', 'unknown')}")
+            msg = f"claude CLI error: {data.get('result', 'unknown')}"
+            if _is_usage_limit_message(str(data.get("result", ""))):
+                raise ClaudeUsageLimitError(msg)
+            raise RuntimeError(msg)
+        self.claude_cli_call_count += 1
         return data["result"]
 
     # -- OpenAI-compat API --------------------------------------------------

--- a/src/applypilot/scoring/cover_letter.py
+++ b/src/applypilot/scoring/cover_letter.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 
 from applypilot.config import COVER_LETTER_DIR, RESUME_PATH, load_profile
 from applypilot.database import get_connection, get_jobs_by_stage
-from applypilot.llm import get_client
+from applypilot.llm import ClaudeUsageLimitError, get_client
 from applypilot.scoring.validator import (
     BANNED_WORDS,
     LLM_LEAK_PHRASES,
@@ -230,6 +230,7 @@ def run_cover_letters(min_score: int = 7, limit: int = 20,
     completed = 0
     results: list[dict] = []
     error_count = 0
+    stopped_on_limit = False
 
     for job in jobs:
         completed += 1
@@ -268,6 +269,10 @@ def run_cover_letters(min_score: int = 7, limit: int = 20,
                 "%d/%d [OK] | %.1f jobs/min | %s",
                 completed, len(jobs), rate * 60, result["title"][:40],
             )
+        except ClaudeUsageLimitError as e:
+            log.error("%d/%d [USAGE LIMIT] stopping run early -- %s", completed, len(jobs), e)
+            stopped_on_limit = True
+            break
         except Exception as e:
             result = {
                 "url": job["url"], "title": job["title"], "site": job["site"],
@@ -296,10 +301,15 @@ def run_cover_letters(min_score: int = 7, limit: int = 20,
     conn.commit()
 
     elapsed = time.time() - t0
-    log.info("Cover letters done in %.1fs: %d generated, %d errors", elapsed, saved, error_count)
+    log.info(
+        "Cover letters done in %.1fs: %d generated, %d errors%s",
+        elapsed, saved, error_count,
+        " (stopped early: usage limit hit)" if stopped_on_limit else "",
+    )
 
     return {
         "generated": saved,
         "errors": error_count,
         "elapsed": elapsed,
+        "stopped_on_limit": stopped_on_limit,
     }

--- a/src/applypilot/scoring/scorer.py
+++ b/src/applypilot/scoring/scorer.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 
 from applypilot.config import RESUME_PATH, load_profile
 from applypilot.database import get_connection, get_jobs_by_stage
-from applypilot.llm import get_client
+from applypilot.llm import ClaudeUsageLimitError, get_client
 
 log = logging.getLogger(__name__)
 
@@ -96,6 +96,8 @@ def score_job(resume_text: str, job: dict) -> dict:
         client = get_client()
         response = client.chat(messages, max_tokens=512, temperature=0.2)
         return _parse_score_response(response)
+    except ClaudeUsageLimitError:
+        raise
     except Exception as e:
         log.error("LLM error scoring job '%s': %s", job.get("title", "?"), e)
         return {"score": 0, "keywords": "", "reasoning": f"LLM error: {e}"}
@@ -137,8 +139,14 @@ def run_scoring(limit: int = 0, rescore: bool = False) -> dict:
     errors = 0
     results: list[dict] = []
 
+    stopped_on_limit = False
     for job in jobs:
-        result = score_job(resume_text, job)
+        try:
+            result = score_job(resume_text, job)
+        except ClaudeUsageLimitError as e:
+            log.error("[%d/%d] [USAGE LIMIT] stopping run early -- %s", completed, len(jobs), e)
+            stopped_on_limit = True
+            break
         result["url"] = job["url"]
         completed += 1
 
@@ -162,7 +170,11 @@ def run_scoring(limit: int = 0, rescore: bool = False) -> dict:
     conn.commit()
 
     elapsed = time.time() - t0
-    log.info("Done: %d scored in %.1fs (%.1f jobs/sec)", len(results), elapsed, len(results) / elapsed if elapsed > 0 else 0)
+    log.info(
+        "Done: %d scored in %.1fs (%.1f jobs/sec)%s",
+        len(results), elapsed, len(results) / elapsed if elapsed > 0 else 0,
+        " (stopped early: usage limit hit)" if stopped_on_limit else "",
+    )
 
     # Score distribution
     dist = conn.execute("""
@@ -177,4 +189,5 @@ def run_scoring(limit: int = 0, rescore: bool = False) -> dict:
         "errors": errors,
         "elapsed": elapsed,
         "distribution": distribution,
+        "stopped_on_limit": stopped_on_limit,
     }

--- a/src/applypilot/scoring/tailor.py
+++ b/src/applypilot/scoring/tailor.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from applypilot.config import RESUME_PATH, TAILORED_DIR, load_profile
 from applypilot.database import get_connection, get_jobs_by_stage
-from applypilot.llm import get_client
+from applypilot.llm import ClaudeUsageLimitError, get_client
 from applypilot.scoring.validator import (
     BANNED_WORDS,
     FABRICATION_WATCHLIST,
@@ -484,6 +484,33 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
     results: list[dict] = []
     stats: dict[str, int] = {"approved": 0, "failed_validation": 0, "failed_judge": 0, "error": 0}
 
+    # Flush to DB every BATCH_SIZE jobs (instead of one commit for the whole
+    # run) so an interrupt or a hit rate limit only loses the in-progress
+    # batch, not everything already tailored.
+    BATCH_SIZE = 5
+    _success_statuses = {"approved", "approved_with_judge_warning"}
+    pending: list[dict] = []
+
+    def _flush(batch: list[dict]) -> None:
+        if not batch:
+            return
+        now = datetime.now(timezone.utc).isoformat()
+        for r in batch:
+            if r["status"] in _success_statuses:
+                conn.execute(
+                    "UPDATE jobs SET tailored_resume_path=?, tailored_at=?, "
+                    "tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
+                    (r["path"], now, r["url"]),
+                )
+            else:
+                conn.execute(
+                    "UPDATE jobs SET tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
+                    (r["url"],),
+                )
+        conn.commit()
+
+    stopped_on_limit = False
+
     for job in jobs:
         completed += 1
         try:
@@ -534,6 +561,19 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
                 "status": report["status"],
                 "attempts": report["attempts"],
             }
+        except ClaudeUsageLimitError as e:
+            # Not a per-job failure -- retrying would just burn more calls
+            # into the same wall. Flush what's already done and stop; this
+            # job's tailor_attempts is left untouched so it's retried fresh
+            # once the limit window resets.
+            log.error(
+                "%d/%d [USAGE LIMIT] stopping run early -- %s",
+                completed, len(jobs), e,
+            )
+            _flush(pending)
+            pending = []
+            stopped_on_limit = True
+            break
         except Exception as e:
             result = {
                 "url": job["url"], "title": job["title"], "site": job["site"],
@@ -542,6 +582,7 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
             log.error("%d/%d [ERROR] %s -- %s", completed, len(jobs), job["title"][:40], e)
 
         results.append(result)
+        pending.append(result)
         stats[result.get("status", "error")] = stats.get(result.get("status", "error"), 0) + 1
 
         elapsed = time.time() - t0
@@ -555,31 +596,19 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
             result["title"][:40],
         )
 
-    # Persist to DB: increment attempt counter for ALL, save path only for approved
-    now = datetime.now(timezone.utc).isoformat()
-    _success_statuses = {"approved", "approved_with_judge_warning"}
-    for r in results:
-        if r["status"] in _success_statuses:
-            conn.execute(
-                "UPDATE jobs SET tailored_resume_path=?, tailored_at=?, "
-                "tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
-                (r["path"], now, r["url"]),
-            )
-        else:
-            conn.execute(
-                "UPDATE jobs SET tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
-                (r["url"],),
-            )
-    conn.commit()
+        if len(pending) >= BATCH_SIZE or completed == len(jobs):
+            _flush(pending)
+            pending = []
 
     elapsed = time.time() - t0
     log.info(
-        "Tailoring done in %.1fs: %d approved, %d failed_validation, %d failed_judge, %d errors",
+        "Tailoring done in %.1fs: %d approved, %d failed_validation, %d failed_judge, %d errors%s",
         elapsed,
         stats.get("approved", 0),
         stats.get("failed_validation", 0),
         stats.get("failed_judge", 0),
         stats.get("error", 0),
+        " (stopped early: usage limit hit)" if stopped_on_limit else "",
     )
 
     return {
@@ -587,4 +616,5 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
         "failed": stats.get("failed_validation", 0) + stats.get("failed_judge", 0),
         "errors": stats.get("error", 0),
         "elapsed": elapsed,
+        "stopped_on_limit": stopped_on_limit,
     }


### PR DESCRIPTION
## Summary

Follow-up safety work for the Claude CLI provider path (#96). This branch is built on top of `add-anthropic-claude-provider`, so the diff below includes that commit plus 2 new ones -- since `main` doesn't have the provider code yet, GitHub will show all 3 until #96 merges. The 2 new commits are the actual content of this PR:

- **Cap claude CLI calls per run**: `LLMClient` now enforces a shared `CLAUDE_CLI_CALL_BUDGET` (default 40) across every stage (score/judge/tailor/cover), raising before spawning another subprocess once hit, instead of relying on each stage to remember to check. Also fixes `scorer.py`/`cover_letter.py` swallowing the usage-limit exception inside a blind `except Exception` and burning through every remaining job anyway. Bumped the CLI subprocess timeout 120s -> 240s (legitimate tailoring prompts were hitting the old timeout, not just rate limits).
- **Stop discovery from capturing non-job API noise as jobs**: the response listener in `smartextract.py` was capturing any response with `/api/` in the URL, including telemetry/auth/consent endpoints job boards fire on page load. These were reaching the LLM judge and, on judge error (fail-open), getting stored as jobs -- wasting a chunk of every run's LLM budget on garbage. Added a denylist at capture time and as a DB-insert backstop, and made the judge fail closed instead of open.

## Test plan

- [x] `ruff check` / `ruff format --check` on all changed files -- no new findings beyond pre-existing debt in files touched
- [x] Verified the call-budget hard stop fires by setting `CLAUDE_CLI_CALL_BUDGET` low and running the pipeline live against my own Claude CLI subscription
- [x] Verified `scorer.py`/`cover_letter.py` now stop cleanly on a real usage-limit hit instead of looping through every remaining job
- [x] Verified the noise-URL denylist against the actual junk endpoints seen in a live run (talent.com auth/telemetry, onetrust.com geolocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)