### PR TITLE
Batch DB commits during score/tailor/cover instead of one commit at the end

### DIFF
--- a/src/applypilot/scoring/cover_letter.py
+++ b/src/applypilot/scoring/cover_letter.py
@@ -230,6 +230,34 @@ def run_cover_letters(min_score: int = 7, limit: int = 20,
     completed = 0
     results: list[dict] = []
     error_count = 0
+    saved = 0
+
+    # Flush to DB every BATCH_SIZE jobs (instead of one commit for the whole
+    # run) so an interrupt partway through only loses the in-progress batch,
+    # not everything already generated.
+    BATCH_SIZE = 5
+    pending: list[dict] = []
+
+    def _flush(batch: list[dict]) -> int:
+        if not batch:
+            return 0
+        now = datetime.now(timezone.utc).isoformat()
+        flushed_saved = 0
+        for r in batch:
+            if r.get("path"):
+                conn.execute(
+                    "UPDATE jobs SET cover_letter_path=?, cover_letter_at=?, "
+                    "cover_attempts=COALESCE(cover_attempts,0)+1 WHERE url=?",
+                    (r["path"], now, r["url"]),
+                )
+                flushed_saved += 1
+            else:
+                conn.execute(
+                    "UPDATE jobs SET cover_attempts=COALESCE(cover_attempts,0)+1 WHERE url=?",
+                    (r["url"],),
+                )
+        conn.commit()
+        return flushed_saved
 
     for job in jobs:
         completed += 1
@@ -277,23 +305,10 @@ def run_cover_letters(min_score: int = 7, limit: int = 20,
             results.append(result)
             log.error("%d/%d [ERROR] %s -- %s", completed, len(jobs), job["title"][:40], e)
 
-    # Persist to DB: increment attempt counter for ALL, save path only for successes
-    now = datetime.now(timezone.utc).isoformat()
-    saved = 0
-    for r in results:
-        if r.get("path"):
-            conn.execute(
-                "UPDATE jobs SET cover_letter_path=?, cover_letter_at=?, "
-                "cover_attempts=COALESCE(cover_attempts,0)+1 WHERE url=?",
-                (r["path"], now, r["url"]),
-            )
-            saved += 1
-        else:
-            conn.execute(
-                "UPDATE jobs SET cover_attempts=COALESCE(cover_attempts,0)+1 WHERE url=?",
-                (r["url"],),
-            )
-    conn.commit()
+        pending.append(result)
+        if len(pending) >= BATCH_SIZE or completed == len(jobs):
+            saved += _flush(pending)
+            pending = []
 
     elapsed = time.time() - t0
     log.info("Cover letters done in %.1fs: %d generated, %d errors", elapsed, saved, error_count)

--- a/src/applypilot/scoring/scorer.py
+++ b/src/applypilot/scoring/scorer.py
@@ -137,6 +137,23 @@ def run_scoring(limit: int = 0, rescore: bool = False) -> dict:
     errors = 0
     results: list[dict] = []
 
+    # Flush to DB every BATCH_SIZE jobs (instead of one commit for the whole
+    # run) so an interrupt partway through only loses the in-progress batch,
+    # not everything already scored.
+    BATCH_SIZE = 5
+    pending: list[dict] = []
+
+    def _flush(batch: list[dict]) -> None:
+        if not batch:
+            return
+        now = datetime.now(timezone.utc).isoformat()
+        for r in batch:
+            conn.execute(
+                "UPDATE jobs SET fit_score = ?, score_reasoning = ?, scored_at = ? WHERE url = ?",
+                (r["score"], f"{r['keywords']}\n{r['reasoning']}", now, r["url"]),
+            )
+        conn.commit()
+
     for job in jobs:
         result = score_job(resume_text, job)
         result["url"] = job["url"]
@@ -146,20 +163,16 @@ def run_scoring(limit: int = 0, rescore: bool = False) -> dict:
             errors += 1
 
         results.append(result)
+        pending.append(result)
 
         log.info(
             "[%d/%d] score=%d  %s",
             completed, len(jobs), result["score"], job.get("title", "?")[:60],
         )
 
-    # Write scores to DB
-    now = datetime.now(timezone.utc).isoformat()
-    for r in results:
-        conn.execute(
-            "UPDATE jobs SET fit_score = ?, score_reasoning = ?, scored_at = ? WHERE url = ?",
-            (r["score"], f"{r['keywords']}\n{r['reasoning']}", now, r["url"]),
-        )
-    conn.commit()
+        if len(pending) >= BATCH_SIZE or completed == len(jobs):
+            _flush(pending)
+            pending = []
 
     elapsed = time.time() - t0
     log.info("Done: %d scored in %.1fs (%.1f jobs/sec)", len(results), elapsed, len(results) / elapsed if elapsed > 0 else 0)

--- a/src/applypilot/scoring/tailor.py
+++ b/src/applypilot/scoring/tailor.py
@@ -484,6 +484,31 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
     results: list[dict] = []
     stats: dict[str, int] = {"approved": 0, "failed_validation": 0, "failed_judge": 0, "error": 0}
 
+    # Flush to DB every BATCH_SIZE jobs (instead of one commit for the whole
+    # run) so an interrupt partway through only loses the in-progress batch,
+    # not everything already tailored.
+    BATCH_SIZE = 5
+    _success_statuses = {"approved", "approved_with_judge_warning"}
+    pending: list[dict] = []
+
+    def _flush(batch: list[dict]) -> None:
+        if not batch:
+            return
+        now = datetime.now(timezone.utc).isoformat()
+        for r in batch:
+            if r["status"] in _success_statuses:
+                conn.execute(
+                    "UPDATE jobs SET tailored_resume_path=?, tailored_at=?, "
+                    "tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
+                    (r["path"], now, r["url"]),
+                )
+            else:
+                conn.execute(
+                    "UPDATE jobs SET tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
+                    (r["url"],),
+                )
+        conn.commit()
+
     for job in jobs:
         completed += 1
         try:
@@ -542,6 +567,7 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
             log.error("%d/%d [ERROR] %s -- %s", completed, len(jobs), job["title"][:40], e)
 
         results.append(result)
+        pending.append(result)
         stats[result.get("status", "error")] = stats.get(result.get("status", "error"), 0) + 1
 
         elapsed = time.time() - t0
@@ -555,22 +581,9 @@ def run_tailoring(min_score: int = 7, limit: int = 20,
             result["title"][:40],
         )
 
-    # Persist to DB: increment attempt counter for ALL, save path only for approved
-    now = datetime.now(timezone.utc).isoformat()
-    _success_statuses = {"approved", "approved_with_judge_warning"}
-    for r in results:
-        if r["status"] in _success_statuses:
-            conn.execute(
-                "UPDATE jobs SET tailored_resume_path=?, tailored_at=?, "
-                "tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
-                (r["path"], now, r["url"]),
-            )
-        else:
-            conn.execute(
-                "UPDATE jobs SET tailor_attempts=COALESCE(tailor_attempts,0)+1 WHERE url=?",
-                (r["url"],),
-            )
-    conn.commit()
+        if len(pending) >= BATCH_SIZE or completed == len(jobs):
+            _flush(pending)
+            pending = []
 
     elapsed = time.time() - t0
     log.info(


### PR DESCRIPTION
## Summary

score, tailor, and cover-letter stages each collected every result in memory and only wrote to the DB in a single commit after the whole job list finished. If the run got interrupted partway through -- rate limit, network drop, killed process, crash -- nothing already completed that run had been persisted, so it was all lost.

- All three stages now flush to the DB every 5 jobs (and on the final job), instead of one commit at the very end.
- Pure DB-durability fix, no provider/LLM-specific changes -- applies cleanly on top of current `main`.

## Test plan

- [x] `ruff check` / `ruff format --check` on all three files -- identical finding count to unmodified `main` (18 pre-existing, 0 new)
- [x] Verified behavior: killed a run mid-batch and confirmed only the in-progress batch (up to 5 jobs) was lost, not the whole run's prior progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)